### PR TITLE
GAC-005 Added IQN super class for later testing.

### DIFF
--- a/policies/gac/gac_networks.py
+++ b/policies/gac/gac_networks.py
@@ -49,7 +49,7 @@ class CosineBasisLinear(tf.Module):
 
 
 class IQNSuperClass(tf.Module):
-    def __init__(self, num_inputs, action_dim, n_basis_functions):
+    def __init__(self):
         super(IQNSuperClass, self).__init__()
 
     def compute_eltwise_huber_quantile_loss(actions, target_actions, taus, weighting):
@@ -76,9 +76,6 @@ class IQNSuperClass(tf.Module):
         eltwise_loss = abs(taus - I_delta) * eltwise_huber_loss * weighting
         return tf.math.reduce_mean(eltwise_loss)
 
-    def __call__(self, state, taus, actions=None):
-        return
-
     def train(self):
         """
         Function to train IQN related classes
@@ -98,11 +95,7 @@ class AutoRegressiveStochasticActor(IQNSuperClass):
             action_dim (int): the dimensionality of the action vector
             n_basis_functions (int): the number of basis functions
         """
-        super(AutoRegressiveStochasticActor, self).__init__(
-            num_inputs,
-            action_dim,
-            n_basis_functions
-        )
+        super(AutoRegressiveStochasticActor, self).__init__()
         # create all necessary class variables
         self.action_dim = action_dim
         self.state_embedding = tf.keras.layers.Dense(
@@ -227,7 +220,7 @@ class StochasticActor(IQNSuperClass):
             action_dim (int): the dimensionality of the action vector
             n_basis_functions (int): the number of basis functions for noise embedding.
         """
-        super(StochasticActor, self).__init__(num_inputs, action_dim, n_basis_functions)
+        super(StochasticActor, self).__init__()
         hidden_size = int(400 / action_dim)
         self.hidden_size = hidden_size
         self.action_dim = action_dim
@@ -252,7 +245,7 @@ class StochasticActor(IQNSuperClass):
             input_shape = (200,)
         )
 
-    def __call__(self, state, taus, actions):
+    def __call__(self, state, taus, actions=None):
         """
         Args:
             state: tensor (batch_size, num_inputs)

--- a/policies/gac/gac_networks.py
+++ b/policies/gac/gac_networks.py
@@ -76,6 +76,9 @@ class IQNSuperClass(tf.Module):
         eltwise_loss = abs(taus - I_delta) * eltwise_huber_loss * weighting
         return tf.math.reduce_mean(eltwise_loss)
 
+    def __call__(self, state, taus, actions=None):
+        return
+
     def train(self):
         """
         Function to train IQN related classes
@@ -83,7 +86,7 @@ class IQNSuperClass(tf.Module):
         return
 
 
-class AutoRegressiveStochasticActor(tf.Module):
+class AutoRegressiveStochasticActor(IQNSuperClass):
     def __init__(self, num_inputs, action_dim, n_basis_functions):
         """
         the autoregressive stochastic actor is an implicit quantile network used to sample from a
@@ -208,7 +211,7 @@ class AutoRegressiveStochasticActor(tf.Module):
         return tf.squeeze(actions, -1)
 
 
-class StochasticActor(tf.Module):
+class StochasticActor(IQNSuperClass):
     def __init__(self, num_inputs, action_dim, n_basis_functions):
         """
         The stochasitc action generator, takes state and tau (random vector) as input, and output
@@ -318,7 +321,7 @@ class Critic(tf.Module):
         else:
             return history1
 
-    
+
     def __call__(self, x):
         # This function returns the value of the forward path given input x
         if self.num_networks == 1:
@@ -349,7 +352,7 @@ class Value(Critic):
         states = tf.broadcast_to(states, [states.shape[0], K] + states.shape[2:])
         # [batch size x K , state dim]
         states = tf.reshape(states, [-1, self.num_inputs])
-        
+
 
         """
         Line 13 of Algorithm 2.

--- a/policies/gac/gac_networks.py
+++ b/policies/gac/gac_networks.py
@@ -72,7 +72,7 @@ class IQNSuperClass(tf.Module):
             Loss for IQN super class
         """
         I_delta = tf.dtypes.cast(((actions - target_actions) > 0), tf.float32)
-        eltwise_huber_loss = tf.keras.losses.huber_loss(target_actions, actions, delta=1.0)
+        eltwise_huber_loss = tf.keras.losses.Huber(delta=1.0)(target_actions, actions)
         eltwise_loss = abs(taus - I_delta) * eltwise_huber_loss * weighting
         return tf.math.reduce_mean(eltwise_loss)
 

--- a/policies/gac/gac_networks.py
+++ b/policies/gac/gac_networks.py
@@ -48,6 +48,41 @@ class CosineBasisLinear(tf.Module):
         return out
 
 
+class IQNSuperClass(tf.Module):
+    def __init__(self, self, num_inputs, action_dim, n_basis_functions):
+        super(IQNSuperClass, self).__init__()
+
+    def compute_eltwise_huber_quantile_loss(actions, target_actions, taus, weighting):
+        """
+        Compute elementwise Huber losses for quantile regression.
+        This is based on Algorithm 1 of https://arxiv.org/abs/1806.06923.
+        This function assumes that, both of the two kinds of quantile thresholds,
+        taus (used to compute y) and taus_prime (used to compute t) are iid samples
+        from U([0,1]).
+
+        Args:
+            actions (tf.Variable): Quantile prediction from taus as a
+                (batch_size, N, K)-shaped array.
+            target_actions (tf.Variable): Quantile targets from taus as a
+                (batch_size, N, K)-shaped array.
+            taus (ndarray): Quantile thresholds used to compute y as a
+                (batch_size, N, 1)-shaped array.
+
+        Returns:
+            Loss for IQN super class
+        """
+        I_delta = tf.dtypes.cast(((actions - target_actions) > 0), tf.float32)
+        eltwise_huber_loss = tf.keras.losses.huber_loss(target_actions, actions, delta=1.0)
+        eltwise_loss = abs(taus - I_delta) * eltwise_huber_loss * weighting
+        return tf.math.reduce_mean(eltwise_loss)
+
+    def train(self):
+        """
+        Function to train IQN related classes
+        """
+        return
+
+
 class AutoRegressiveStochasticActor(tf.Module):
     def __init__(self, num_inputs, action_dim, n_basis_functions):
         """

--- a/policies/gac/gac_networks.py
+++ b/policies/gac/gac_networks.py
@@ -49,7 +49,7 @@ class CosineBasisLinear(tf.Module):
 
 
 class IQNSuperClass(tf.Module):
-    def __init__(self, self, num_inputs, action_dim, n_basis_functions):
+    def __init__(self, num_inputs, action_dim, n_basis_functions):
         super(IQNSuperClass, self).__init__()
 
     def compute_eltwise_huber_quantile_loss(actions, target_actions, taus, weighting):
@@ -98,7 +98,11 @@ class AutoRegressiveStochasticActor(IQNSuperClass):
             action_dim (int): the dimensionality of the action vector
             n_basis_functions (int): the number of basis functions
         """
-        super(AutoRegressiveStochasticActor, self).__init__()
+        super(AutoRegressiveStochasticActor, self).__init__(
+            num_inputs,
+            action_dim,
+            n_basis_functions
+        )
         # create all necessary class variables
         self.action_dim = action_dim
         self.state_embedding = tf.keras.layers.Dense(
@@ -223,7 +227,7 @@ class StochasticActor(IQNSuperClass):
             action_dim (int): the dimensionality of the action vector
             n_basis_functions (int): the number of basis functions for noise embedding.
         """
-        super(StochasticActor, self).__init__()
+        super(StochasticActor, self).__init__(num_inputs, action_dim, n_basis_functions)
         hidden_size = int(400 / action_dim)
         self.hidden_size = hidden_size
         self.action_dim = action_dim


### PR DESCRIPTION
I created a super class to encompass both the AIQN and IQN.

```root@77c76caacdfe:/usr/src/app# python3 -m tests.unit.unit_test_suites
Running tests from: /usr/src/app/tests/unit/policies/gac/gac_networks.py
2019-10-26 04:00:02.287676: I tensorflow/stream_executor/platform/default/dso_loader.cc:44] Successfully opened dynamic library libcuda.so.1
2019-10-26 04:00:02.287742: E tensorflow/stream_executor/cuda/cuda_driver.cc:318] failed call to cuInit: UNKNOWN ERROR (-1)
2019-10-26 04:00:02.287785: I tensorflow/stream_executor/cuda/cuda_diagnostics.cc:156] kernel driver does not appear to be running on this host (77c76caacdfe): /proc/driver/nvidia/version does not exist
2019-10-26 04:00:02.288048: I tensorflow/core/platform/cpu_feature_guard.cc:142] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA
2019-10-26 04:00:02.295241: I tensorflow/core/platform/profile_utils/cpu_utils.cc:94] CPU Frequency: 2492025000 Hz
2019-10-26 04:00:02.296546: I tensorflow/compiler/xla/service/service.cc:168] XLA service 0x53de970 executing computations on platform Host. Devices:
2019-10-26 04:00:02.296594: I tensorflow/compiler/xla/service/service.cc:175]   StreamExecutor device (0): Host, Default Version
...WARNING:tensorflow:Falling back from v2 loop because of error: Failed to find data adapter that can handle input: <class 'tensorflow.python.ops.resource_variable_ops.ResourceVariable'>, <class 'NoneType'>
..
----------------------------------------------------------------------
Ran 5 tests in 0.521s

OK```